### PR TITLE
Added .from(object) method, re-use tween objects

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -129,7 +129,16 @@ TWEEN.Tween = function (object) {
 	for (var field in object) {
 		_valuesStart[field] = parseFloat(object[field], 10);
 	}
-
+	
+	//reset all starting values present in a target object
+	this.from = function(object) {
+	    _object = object;
+	    for (var field in object) {
+    		_valuesStart[field] = parseFloat(object[field], 10);
+	    	}
+	    return this;
+	};
+	
 	this.to = function (properties, duration) {
 
 		if (duration !== undefined) {


### PR DESCRIPTION
In a game or high performance application, creating new objects that may have repeated use puts burden on the garbage collector and could negatively impact performance.

By adding one method to reset the tween, you can keep an "object pool" by storing references and re-use the object.

I've been using this in a beta application for a couple of months and it works great, profiled several times in Chrome Dev Tools.
